### PR TITLE
fix: Windows path handling and extension filtering

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -41,10 +41,17 @@ impl Task {
         }
         arguments.extend(iterator);
         if let Some(program) = arguments.get(0) {
-            if program.ends_with("duckdb-ext-build") {
+            let program_base = std::path::Path::new(program)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(program)
+                .strip_suffix(".exe")
+                .unwrap_or(program);
+                
+            if program_base.ends_with("duckdb-ext-build") {
                 return Task::Build(arguments);
             }
-            if program.ends_with("duckdb-ext-pack") {
+            if program_base.ends_with("duckdb-ext-pack") {
                 return Task::Pack(arguments);
             }
         }


### PR DESCRIPTION
- Add Windows path normalization to strip extended-length device path prefixes
- Filter dynamic library files more precisely to avoid using the pdb when packing the extension
- Fix program name detection on Windows for .exe suffixes

Fixes #1

### Investigation logs
```
❯ cargo install cargo-generate
❯ cargo generate --git https://github.com/redraiment/duckdb-ext-rs-template -n quack
❯ cd quack
❯ cargo install cargo-duckdb-ext-tools
❯ cargo duckdb-ext-build
[...]
❯ eza .\target\debug\ -l
d----    - 27 Dec 19:45 build
d----    - 27 Dec 19:46 deps
d----    - 27 Dec 19:45 examples
d----    - 27 Dec 19:46 incremental
-a---  103 27 Dec 19:46 quack.d
-a--- 436k 27 Dec 19:46 quack.dll
-a---  862 27 Dec 19:46 quack.dll.exp
-a--- 1.7k 27 Dec 19:46 quack.dll.lib
-a---  39M 27 Dec 19:46 quack.pdb
```

`quack.duckdb_extension` is missing.

Applied only the path normalization part of the fix and rebuild local tools
```
❯ cd ../cargo-duckdb-ext-tools
❯ cargo build --release
[...]
❯ cargo install --path .
[...]
    Finished `release` profile [optimized] target(s) in 19.90s
   Replacing C:\Users\neb\.cargo\bin\cargo-duckdb-ext-build.exe
   Replacing C:\Users\neb\.cargo\bin\cargo-duckdb-ext-pack.exe
    Replaced package `cargo-duckdb-ext-tools v0.4.0` with `cargo-duckdb-ext-tools v0.4.0 (D:\Development\cargo-duckdb-ext-tools)` (executables `cargo-duckdb-ext-build.exe`, `cargo-duckdb-ext-pack.exe`)

// Now rebuild the extension
❯ cd ../quack

❯ cargo duckdb-ext-build
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Copying Library File (D:\Development\ChessKitchen\quack\target\debug\quack.dll)
     Copying Extension File (D:\Development\ChessKitchen\quack\target\debug\quack.duckdb_extension)
     Copying Library File (D:\Development\ChessKitchen\quack\target\debug\quack.dll.lib)
     Copying Extension File (D:\Development\ChessKitchen\quack\target\debug\quack.duckdb_extension)
     Copying Library File (D:\Development\ChessKitchen\quack\target\debug\quack.dll.exp)
     Copying Extension File (D:\Development\ChessKitchen\quack\target\debug\quack.duckdb_extension)
     Copying Library File (D:\Development\ChessKitchen\quack\target\debug\quack.pdb)
     Copying Extension File (D:\Development\ChessKitchen\quack\target\debug\quack.duckdb_extension)
     Packing ABI Type (C_STRUCT_UNSTABLE)
     Packing Extension Version (v0.1.0)
     Packing DuckDB Version (v1.4.3)
     Packing DuckDB Platform (windows_amd64)
    Finished DuckDB Extension
     Packing ABI Type (C_STRUCT_UNSTABLE)
     Packing Extension Version (v0.1.0)
     Packing DuckDB Version (v1.4.3)
     Packing DuckDB Platform (windows_amd64)
    Finished DuckDB Extension
     Packing ABI Type (C_STRUCT_UNSTABLE)
     Packing Extension Version (v0.1.0)
     Packing DuckDB Version (v1.4.3)
     Packing DuckDB Platform (windows_amd64)
    Finished DuckDB Extension
     Packing ABI Type (C_STRUCT_UNSTABLE)
     Packing Extension Version (v0.1.0)
     Packing DuckDB Version (v1.4.3)
     Packing DuckDB Platform (windows_amd64)
    Finished DuckDB Extension

❯ eza .\target\debug\ -l
d----    - 27 Dec 19:45 build
d----    - 27 Dec 19:46 deps
d----    - 27 Dec 19:45 examples
d----    - 27 Dec 19:46 incremental
-a---  103 27 Dec 19:46 quack.d
-a--- 436k 27 Dec 19:46 quack.dll
-a---  862 27 Dec 19:46 quack.dll.exp
-a--- 1.7k 27 Dec 19:46 quack.dll.lib
-a--- 436k 27 Dec 19:49 quack.duckdb_extension
-a---  39M 27 Dec 19:46 quack.pdb
```
It's now generated. But...

```
❯ duckdb -unsigned -c "load 'target/debug/quack.duckdb_extension'; from quack('Joe')"
IO Error:
Extension "target\debug\quack.duckdb_extension" could not be loaded: %1 is not a valid Win32 application.
```

After a bit of digging, realized that the metadata was applied 4 files, one for each artifacts found (see log above). The pdb processing being the main culprit for the loading error, but I've filtered the others as well to avoid doing the same thing multiple times. 

With the rest of the fix in this PR applied.
``` 
❯ cargo duckdb-ext-build
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
     Copying Library File (D:\Development\ChessKitchen\quack\target\debug\quack.dll)
     Copying Extension File (D:\Development\ChessKitchen\quack\target\debug\quack.duckdb_extension)
     Packing ABI Type (C_STRUCT_UNSTABLE)
     Packing Extension Version (v0.1.0)
     Packing DuckDB Version (v1.4.3)
     Packing DuckDB Platform (windows_amd64)
    Finished DuckDB Extension

❯ duckdb -unsigned -c "load 'target/debug/quack.duckdb_extension'; from quack('Joe')"
┌───────────┐
│    ??     │
│  varchar  │
├───────────┤
│ Hello Joe │
└───────────┘
```